### PR TITLE
Fix AttributeError: 'Message' object has no attribute 'message_id'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pyrogram
+Pyrogram==1.4.12
 TgCrypto
 ffmpeg
 hachoir


### PR DESCRIPTION
Since pyrogram new version has brought many changes to [available objects](https://docs.pyrogram.org/api/types/) and [available methods](https://docs.pyrogram.org/api/methods/), the latest version would not work with this program. Downgrading to an older version helped on fixing this issue. 

## Changes
- Specify pyrogram version implicitly